### PR TITLE
JAMF keeps removing our Puppet Managed Profile for munki via it's top level PayloadIdentifier

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -83,7 +83,7 @@ class munki::config {
     'PayloadContent' => [
       {
         'PayloadContent' => {
-          'ManagedInstalls' => {
+          'Managed_installs' => {
             'Forced' => [
               {
                 'mcx_preference_settings' => $settings_to_write
@@ -92,25 +92,25 @@ class munki::config {
           }
         },
         'PayloadEnabled' => true,
-        'PayloadIdentifier' => 'MCXToProfile.1dc15df4-d4c4-4b3a-b507-dd8f3b44f093.alacarte.customsettings.2beb4aeb-861b-4000-8c3a-d05117bf5ba7', # lint:ignore:140chars
+        'PayloadIdentifier' => 'com.yelpcorp.Managed_installs',
         'PayloadType' => 'com.apple.ManagedClient.preferences',
-        'PayloadUUID' => '2beb4aeb-861b-4000-8c3a-d05117bf5ba7',
+        'PayloadUUID' => '59656c70d-eb90-4ee2-a487-4cbe1e9b7ec1',
         'PayloadVersion' => 1
       }
     ],
-    'PayloadDescription' => "Included custom settings:\nManagedInstalls",
+    'PayloadDescription' => "Included custom settings:\Managed_installs",
     'PayloadDisplayName' => 'Settings for Munki',
-    'PayloadIdentifier' => 'ManagedInstalls',
+    'PayloadIdentifier' => 'Managed_installs',
     'PayloadOrganization' => $payload_organization,
     'PayloadRemovalDisallowed' => true,
     'PayloadScope' => 'System',
     'PayloadType' => 'Configuration',
-    'PayloadUUID' => '1dc15df4-d4c4-4b3a-b507-dd8f3b44f093',
+    'PayloadUUID' => '59656c70f-73f8-495e-a5d6-4e3753f21c2d',
     'PayloadVersion' => 1
   }
 
-  mac_profiles_handler::manage { 'ManagedInstalls':
-    ensure      => absent,
+  mac_profiles_handler::manage { 'Managed_installs':
+    ensure      => present,
     file_source => plist($profile),
     type        => 'template',
   }


### PR DESCRIPTION
JAMF is currently nuking our puppet profile which manages our settings for munki.

We need the puppet managed profile to remain in place without JAMF harassing it, so I modified the top level PayloadIdentifier key to a different value to prevent JAMF from removing the profile.

I also modified the lower level PayloadIdentifer key and both PayloadUUID's as well as the Payload Description just to be consistent and practice good.

To test this you'll need to modify your hashes and ref's in your Puppet and Puppet.lock files to reflect the Yelp/Puppet-munki fork address for modules.
Address: https://github.com/Yelp/puppet-munki.git
Hash: c48f09e0cb8af6c32aa1e5dc41c8e9a51467d4c1
You need to enter the complete hash from this commit.

Darwin.yaml also requires:
`munki::client_resources_filename: 'bigsur_resources'`
`munki::client_resources_url: 'https://munki.yelpcorp.com/munki_repo/client_resources/'`

Then run Puppet and it'll download the freshly configured version of the munki profile which JAMF cannot remove.
https://fluffy.yelpcorp.com/i/Z78kHL9g626Zw3M55LBFFmBLVjvlK6GV.html