### PR TITLE
OG version with new lower level PayloadIdentifier

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -83,7 +83,7 @@ class munki::config {
     'PayloadContent' => [
       {
         'PayloadContent' => {
-          'Managed_installs' => {
+          'ManagedInstalls' => {
             'Forced' => [
               {
                 'mcx_preference_settings' => $settings_to_write
@@ -92,20 +92,20 @@ class munki::config {
           }
         },
         'PayloadEnabled' => true,
-        'PayloadIdentifier' => 'com.yelpcorp.Managed_installs',
+        'PayloadIdentifier' => 'MCXToProfile.1dc15df4-d4c4-4b3a-b507-dd8f3b44f093.alacarte.customsettings.2beb4aeb-861b-4000-8c3a-d05117bf5ba7', # lint:ignore:140chars
         'PayloadType' => 'com.apple.ManagedClient.preferences',
-        'PayloadUUID' => '59656c70d-eb90-4ee2-a487-4cbe1e9b7ec1',
+        'PayloadUUID' => '2beb4aeb-861b-4000-8c3a-d05117bf5ba7',
         'PayloadVersion' => 1
       }
     ],
-    'PayloadDescription' => "Included custom settings:\Managed_installs",
+    'PayloadDescription' => "Included custom settings:\nManagedInstalls",
     'PayloadDisplayName' => 'Settings for Munki',
-    'PayloadIdentifier' => 'Managed_installs',
+    'PayloadIdentifier' => 'Managed_Installs',
     'PayloadOrganization' => $payload_organization,
     'PayloadRemovalDisallowed' => true,
     'PayloadScope' => 'System',
     'PayloadType' => 'Configuration',
-    'PayloadUUID' => '59656c70f-73f8-495e-a5d6-4e3753f21c2d',
+    'PayloadUUID' => '1dc15df4-d4c4-4b3a-b507-dd8f3b44f093',
     'PayloadVersion' => 1
   }
 


### PR DESCRIPTION
Hahahah okay it works this time!

I undid all the changes in the previous PR with the exception of the lower level PayloadIdentifier.

Ran Puppet with it pointed to this, profile installed, ran jamf, it survived, `managedsoftwareupdate --show` everything stuck.

I also ran recon like 4 more times, survived and settings stuck