### PR TITLE
Hurricane/puppet max files

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -20,9 +20,10 @@ class munki::install {
   # Make sure everything is owned by root
   if $facts['munki_dir_exists'] == true {
     file {'/usr/local/munki':
-      owner   => 'root',
-      group   => 'wheel',
-      recurse => true,
+      owner     => 'root',
+      group     => 'wheel',
+      recurse   => true,
+      max_files => -1,
     }
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -25,5 +25,4 @@ class munki::install {
       recurse => true,
     }
   }
-
 }


### PR DESCRIPTION
Put to death the annoying warning:

https://github.com/airbnb/puppet-munki/issues/17

Yelp has all nodes running puppet 7 and greater.