### PR TITLE
Hurricane/allow disabling of munki services

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -15,6 +15,14 @@ class munki::service {
 
   exit 0'
 
+  $app_usage_cmd = '# get console UID
+  consoleuser=`/usr/bin/stat -f "%u" /dev/console`
+
+  /bin/launchctl bootout gui/$consoleuser /Library/LaunchAgents/com.googlecode.munki.app_usage_monitor.plist
+  /bin/launchctl bootstrap gui/$consoleuser /Library/LaunchAgents/com.googlecode.munki.app_usage_monitor.plist
+
+  exit 0'
+
   service { 'com.googlecode.munki.managedsoftwareupdate-check':
     ensure => 'running',
     enable => true,
@@ -24,85 +32,38 @@ class munki::service {
     ensure => 'running',
     enable => true,
   }
-
   -> service { 'com.googlecode.munki.managedsoftwareupdate-manualcheck':
     ensure => 'running',
     enable => true,
   }
 
-  if versioncmp($facts['munki_version'], '3.3.0') >= 0 {
-    service { 'com.googlecode.munki.appusaged':
-      ensure  => 'running',
-      enable  => true,
-      require => Service['com.googlecode.munki.managedsoftwareupdate-manualcheck']
-    }
-
-    -> exec { 'munki_reload_launchagents':
-      command     => $post_v3_agents_cmd,
-      path        => '/bin:/sbin:/usr/bin:/usr/sbin',
-      provider    => 'shell',
-      refreshonly => true,
-      notify      => Exec['munki_app_usage_agent']
-    }
-
-    -> exec {'munki_app_usage_agent':
-      command     => '# get console UID
-  consoleuser=`/usr/bin/stat -f "%u" /dev/console`
-
-  /bin/launchctl bootout gui/$consoleuser /Library/LaunchAgents/com.googlecode.munki.app_usage_monitor.plist
-  /bin/launchctl bootstrap gui/$consoleuser /Library/LaunchAgents/com.googlecode.munki.app_usage_monitor.plist
-
-  exit 0',
-      path        => '/bin:/sbin:/usr/bin:/usr/sbin',
-      provider    => 'shell',
-      refreshonly => true,
-    }
-
-    exec {'munki unload old app usgae':
-      command     => '/bin/launchctl unload /Library/LaunchDaemons/com.googlecode.munki.app_usage_monitor.plist
-      exit 0',
-      provider    => 'shell',
-      refreshonly => true,
-      before      => File['/Library/LaunchDaemons/com.googlecode.munki.app_usage_monitor.plist']
-    }
-
-    -> file {'/Library/LaunchDaemons/com.googlecode.munki.app_usage_monitor.plist':
-      ensure => absent
-    }
-
+  service { 'com.googlecode.munki.appusaged':
+    ensure  => 'running',
+    enable  => true,
+    require => Service['com.googlecode.munki.managedsoftwareupdate-manualcheck']
+  }
+  -> exec { 'munki_reload_launchagents':
+    command     => $post_v3_agents_cmd,
+    path        => '/bin:/sbin:/usr/bin:/usr/sbin',
+    provider    => 'shell',
+    refreshonly => true,
+    notify      => Exec['munki_app_usage_agent']
+  }
+  -> exec {'munki_app_usage_agent':
+    command     => $app_usage_cmd,
+    path        => '/bin:/sbin:/usr/bin:/usr/sbin',
+    provider    => 'shell',
+    refreshonly => true,
   }
 
-  elsif versioncmp($facts['munki_version'], '3.0.0') >= 0 {
-    service { 'com.googlecode.munki.app_usage_monitor':
-      ensure  => 'running',
-      enable  => true,
-      require => Service['com.googlecode.munki.managedsoftwareupdate-manualcheck']
-    }
-
-    -> exec { 'munki_reload_launchagents':
-      command     => $post_v3_agents_cmd,
-      path        => '/bin:/sbin:/usr/bin:/usr/sbin',
-      provider    => 'shell',
-      refreshonly => true,
-    }
-  } else {
-    exec { 'munki_reload_launchagents':
-      command     => '# get console UID
-  consoleuser=`/usr/bin/stat -f "%u" /dev/console`
-
-  /bin/launchctl bootout gui/$consoleuser /Library/LaunchAgents/com.googlecode.munki.ManagedSoftwareCenter.plist
-  /bin/launchctl bootout gui/$consoleuser /Library/LaunchAgents/com.googlecode.munki.MunkiStatus.plist
-  /bin/launchctl bootout gui/$consoleuser /Library/LaunchAgents/com.googlecode.munki.managedsoftwareupdate-loginwindow.plist
-  /bin/launchctl bootstrap gui/$consoleuser /Library/LaunchAgents/com.googlecode.munki.ManagedSoftwareCenter.plist
-  /bin/launchctl bootstrap gui/$consoleuser /Library/LaunchAgents/com.googlecode.munki.MunkiStatus.plist
-  /bin/launchctl bootstrap gui/$consoleuser /Library/LaunchAgents/com.googlecode.munki.managedsoftwareupdate-loginwindow.plist
-
-  exit 0',
-      path        => '/bin:/sbin:/usr/bin:/usr/sbin',
-      provider    => 'shell',
-      refreshonly => true,
-      require     => Service['com.googlecode.munki.managedsoftwareupdate-manualcheck']
-    }
+  exec {'munki unload old app usgae':
+    command     => '/bin/launchctl unload /Library/LaunchDaemons/com.googlecode.munki.app_usage_monitor.plist
+    exit 0',
+    provider    => 'shell',
+    refreshonly => true,
+    before      => File['/Library/LaunchDaemons/com.googlecode.munki.app_usage_monitor.plist']
   }
-
+  -> file {'/Library/LaunchDaemons/com.googlecode.munki.app_usage_monitor.plist':
+    ensure => absent
+  }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -55,15 +55,4 @@ class munki::service {
     provider    => 'shell',
     refreshonly => true,
   }
-
-  exec {'munki unload old app usgae':
-    command     => '/bin/launchctl unload /Library/LaunchDaemons/com.googlecode.munki.app_usage_monitor.plist
-    exit 0',
-    provider    => 'shell',
-    refreshonly => true,
-    before      => File['/Library/LaunchDaemons/com.googlecode.munki.app_usage_monitor.plist']
-  }
-  -> file {'/Library/LaunchDaemons/com.googlecode.munki.app_usage_monitor.plist':
-    ensure => absent
-  }
 }


### PR DESCRIPTION
When using this module to managed installs on headless worker nodes, it would be beneficial to be able disable services. These services can at times  be CPU and IO intensive, which would negatively impact nodes that are in the midst of CI/CD runs.